### PR TITLE
Validate observation shape before IK solve

### DIFF
--- a/scripts/teleop/run_teleop.py
+++ b/scripts/teleop/run_teleop.py
@@ -100,7 +100,10 @@ class TeleopIkSolver():
         button_data = self.button_data
         trigger_data = self.trigger_data
 
-        assert obs.shape == (self.robot.model.nq,)
+        if obs.shape != (self.robot.model.nq,):
+            raise ValueError(
+                f"Observation vector must have shape ({self.robot.model.nq},), got {obs.shape}"
+            )
 
         data = self.robot.data.copy()
         # Update pinocchio data


### PR DESCRIPTION
## Summary
- replace observation shape assert with explicit ValueError in teleop solver

## Testing
- `pytest -q` *(fails: could not open port /dev/ttyUSB0; ImportError: cannot import name 'SortImports' from 'isort')*

------
https://chatgpt.com/codex/tasks/task_e_688d6c0252d08329b1f1965956191ddd