### PR TITLE
Use relative paths for MJCF models

### DIFF
--- a/source/berkeley_humanoid_lite/berkeley_humanoid_lite/environments/mujoco.py
+++ b/source/berkeley_humanoid_lite/berkeley_humanoid_lite/environments/mujoco.py
@@ -1,6 +1,7 @@
 
 import time
 import threading
+from pathlib import Path
 
 import numpy as np
 import torch
@@ -34,10 +35,18 @@ class MujocoEnv:
         self.cfg = cfg
 
         # Load appropriate MJCF model based on robot configuration
+        assets_dir = (
+            Path(__file__).resolve().parents[3]
+            / "berkeley_humanoid_lite_assets"
+            / "data"
+            / "mjcf"
+        )
         if cfg.num_joints == 22:
-            self.mj_model = mujoco.MjModel.from_xml_path("source/berkeley_humanoid_lite_assets/data/mjcf/bhl_scene.xml")
+            mjcf_file = assets_dir / "bhl_scene.xml"
         else:
-            self.mj_model = mujoco.MjModel.from_xml_path("source/berkeley_humanoid_lite_assets/data/mjcf/bhl_biped_scene.xml")
+            mjcf_file = assets_dir / "bhl_biped_scene.xml"
+
+        self.mj_model = mujoco.MjModel.from_xml_path(str(mjcf_file))
 
         self.mj_data = mujoco.MjData(self.mj_model)
         self.mj_model.opt.timestep = self.cfg.physics_dt


### PR DESCRIPTION
## Summary
- import pathlib and compute asset paths relative to the environment module
- load MJCF models from these dynamically built paths rather than hard-coded strings

## Testing
- `pytest` (fails: could not open port /dev/ttyUSB0; ModuleNotFoundError: meshcat_shapes)
- `python - <<'PY' ...` (outputs humanoid and biped MJCF paths and existence flags)


------
https://chatgpt.com/codex/tasks/task_e_688d6bf9aa288329bedfbcaad838e29a