### PR TITLE
Use from_numpy for base state getters

### DIFF
--- a/source/berkeley_humanoid_lite/berkeley_humanoid_lite/environments/mujoco.py
+++ b/source/berkeley_humanoid_lite/berkeley_humanoid_lite/environments/mujoco.py
@@ -114,6 +114,11 @@ class MujocoSimulator(MujocoEnv):
         self.sensordata_dof_size = 3 * self.mj_model.nu
         self.gravity_vector = torch.tensor([0.0, 0.0, -1.0])
 
+        # Cache buffers to avoid reallocation in sensor getters
+        self._base_pos_cache = torch.zeros(3, dtype=torch.float32)
+        self._base_quat_cache = torch.zeros(4, dtype=torch.float32)
+        self._base_ang_vel_cache = torch.zeros(3, dtype=torch.float32)
+
         # Initialize control parameters
         self.joint_kp = torch.zeros((self.cfg.num_joints,), dtype=torch.float32)
         self.joint_kd = torch.zeros((self.cfg.num_joints,), dtype=torch.float32)
@@ -206,7 +211,10 @@ class MujocoSimulator(MujocoEnv):
         Returns:
             torch.Tensor: Base position [x, y, z]
         """
-        return torch.tensor(self.mj_data.qpos[:3], dtype=torch.float32)
+        self._base_pos_cache.copy_(
+            torch.from_numpy(self.mj_data.qpos[:3].copy()).float()
+        )
+        return self._base_pos_cache
 
     def _get_base_quat(self) -> torch.Tensor:
         """Get base orientation quaternion from sensors.
@@ -214,8 +222,14 @@ class MujocoSimulator(MujocoEnv):
         Returns:
             torch.Tensor: Base orientation quaternion [w, x, y, z]
         """
-        return torch.tensor(self.mj_data.sensordata[self.sensordata_dof_size+0:self.sensordata_dof_size+4],
-                          dtype=torch.float32)
+        self._base_quat_cache.copy_(
+            torch.from_numpy(
+                self.mj_data.sensordata[
+                    self.sensordata_dof_size : self.sensordata_dof_size + 4
+                ].copy()
+            ).float()
+        )
+        return self._base_quat_cache
 
     def _get_base_ang_vel(self) -> torch.Tensor:
         """Get base angular velocity from sensors.
@@ -223,8 +237,14 @@ class MujocoSimulator(MujocoEnv):
         Returns:
             torch.Tensor: Base angular velocity [wx, wy, wz]
         """
-        return torch.tensor(self.mj_data.sensordata[self.sensordata_dof_size+4:self.sensordata_dof_size+7],
-                          dtype=torch.float32)
+        self._base_ang_vel_cache.copy_(
+            torch.from_numpy(
+                self.mj_data.sensordata[
+                    self.sensordata_dof_size + 4 : self.sensordata_dof_size + 7
+                ].copy()
+            ).float()
+        )
+        return self._base_ang_vel_cache
 
     def _get_projected_gravity(self) -> torch.Tensor:
         """Get gravity vector in the robot's base frame.


### PR DESCRIPTION
## Summary
- cache base position, orientation, and angular velocity tensors
- replace `torch.tensor` with `torch.from_numpy(...).float()` using safe copies

## Testing
- `pytest` *(fails: FileNotFoundError: [Errno 2] No such file or directory: '/dev/ttyUSB0')*


------
https://chatgpt.com/codex/tasks/task_e_688d6bf3cc7c8329a23291933707cf66