### PR TITLE
Fix motor configuration JSON

### DIFF
--- a/motor_configuration.json
+++ b/motor_configuration.json
@@ -7,8 +7,8 @@
         "velocity_ki": 0.0,
         "torque_limit": 1.0,
         "velocity_limit": 20.0,
-        "position_limit_upper": Infinity,
-        "position_limit_lower": -Infinity,
+        "position_limit_upper": 1e9,
+        "position_limit_lower": -1e9,
         "position_offset": 0.0,
         "torque_filter_alpha": 0.2695973217487335
     },

--- a/tests/test_motor_config.py
+++ b/tests/test_motor_config.py
@@ -1,0 +1,20 @@
+import json
+import math
+from pathlib import Path
+
+
+def _check_finite(value):
+    if isinstance(value, dict):
+        for v in value.values():
+            _check_finite(v)
+    elif isinstance(value, list):
+        for v in value:
+            _check_finite(v)
+    elif isinstance(value, (int, float)):
+        assert math.isfinite(value), "Non-finite number in motor configuration"
+
+
+def test_motor_configuration_all_numbers_finite():
+    cfg_path = Path('motor_configuration.json')
+    data = json.loads(cfg_path.read_text())
+    _check_finite(data)


### PR DESCRIPTION
## Summary
- replace non-standard infinities in motor configuration with large finite bounds
- add regression test to ensure motor configuration contains only finite numeric values

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688d7421076c83298f45f12e73168d8a