### PR TITLE
Add lighting randomization events

### DIFF
--- a/source/berkeley_humanoid_lite/berkeley_humanoid_lite/tasks/locomotion/velocity/config/humanoid/env_cfg.py
+++ b/source/berkeley_humanoid_lite/berkeley_humanoid_lite/tasks/locomotion/velocity/config/humanoid/env_cfg.py
@@ -273,6 +273,25 @@ class EventsCfg:
         mode="startup",
     )
 
+    randomize_light = EventTerm(
+        func=mdp.randomize_light,
+        params={
+            "asset_cfg": SceneEntityCfg("light"),
+            "color_range": ((0.5, 1.0), (0.5, 1.0), (0.5, 1.0)),
+            "intensity_range": (2000.0, 4000.0),
+        },
+        mode="startup",
+    )
+    randomize_sky_light = EventTerm(
+        func=mdp.randomize_light,
+        params={
+            "asset_cfg": SceneEntityCfg("sky_light"),
+            "color_range": ((0.1, 0.3), (0.1, 0.3), (0.1, 0.3)),
+            "intensity_range": (500.0, 1500.0),
+        },
+        mode="startup",
+    )
+
     # === Reset behaviors ===
     reset_base = EventTerm(
         func=mdp.reset_root_state_uniform,

--- a/source/berkeley_humanoid_lite/berkeley_humanoid_lite/tasks/locomotion/velocity/mdp/events.py
+++ b/source/berkeley_humanoid_lite/berkeley_humanoid_lite/tasks/locomotion/velocity/mdp/events.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import torch
 from typing import TYPE_CHECKING, Literal
 
-from isaaclab.assets import Articulation
+from isaaclab.assets import Articulation, Light
 from isaaclab.envs.mdp.events import _randomize_prop_by_op
 from isaaclab.managers import SceneEntityCfg
 import isaaclab.utils.math as math_utils
@@ -92,3 +92,45 @@ def randomize_actuator_torque_constant(
 
                 asset.write_joint_stiffness_to_sim(stiffness, joint_ids=actuator.joint_indices, env_ids=env_ids)
                 asset.write_joint_damping_to_sim(damping, joint_ids=actuator.joint_indices, env_ids=env_ids)
+
+
+def randomize_light(
+    env: ManagerBasedEnv,
+    env_ids: torch.Tensor | None,
+    asset_cfg: SceneEntityCfg,
+    color_range: tuple[tuple[float, float], tuple[float, float], tuple[float, float]] | None = None,
+    intensity_range: tuple[float, float] | None = None,
+):
+    """Randomize the color and intensity of a light asset."""
+
+    asset: Light = env.scene[asset_cfg.name]
+
+    if env_ids is None:
+        env_ids = torch.arange(env.scene.num_envs, device=asset.device)
+
+    if color_range is not None:
+        r = torch.rand(len(env_ids), device=asset.device)
+        g = torch.rand(len(env_ids), device=asset.device)
+        b = torch.rand(len(env_ids), device=asset.device)
+        colors = torch.stack(
+            [
+                r * (color_range[0][1] - color_range[0][0]) + color_range[0][0],
+                g * (color_range[1][1] - color_range[1][0]) + color_range[1][0],
+                b * (color_range[2][1] - color_range[2][0]) + color_range[2][0],
+            ],
+            dim=-1,
+        )
+        if hasattr(asset, "set_color"):
+            asset.set_color(colors, env_ids=env_ids)
+        elif hasattr(asset, "data") and hasattr(asset.data, "color"):
+            asset.data.color[env_ids] = colors
+
+    if intensity_range is not None:
+        intensities = (
+            torch.rand(len(env_ids), device=asset.device) * (intensity_range[1] - intensity_range[0])
+            + intensity_range[0]
+        )
+        if hasattr(asset, "set_intensity"):
+            asset.set_intensity(intensities, env_ids=env_ids)
+        elif hasattr(asset, "data") and hasattr(asset.data, "intensity"):
+            asset.data.intensity[env_ids] = intensities


### PR DESCRIPTION
## Summary
- add utility to randomize light color and intensity
- randomize scene lights on environment startup

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68989d80d408832987e65aa38f6e6521